### PR TITLE
Allow public access to the fields of beacon

### DIFF
--- a/Sources/SDBeaconScanner/Beacon.swift
+++ b/Sources/SDBeaconScanner/Beacon.swift
@@ -10,23 +10,23 @@ import CoreLocation
 /// A struct representing a beacon that has been scanned.
 public struct Beacon {
     /// The UUID of the scanned beacon.
-    let uuid: String
+    public let uuid: String
 
     /// The major of the scanned beacon.
-    let major: Int
+    public let major: Int
 
     /// The minor of the scanned beacon
-    let minor: Int
+    public let minor: Int
 
     /// The RSSI of the scanned beacon
-    let rssi: Int
+    public let rssi: Int
 
     /// The proximity of the scanned beacon
-    let proximity: CLProximity
+    public let proximity: CLProximity
 
     /// The accuracy of the proximity value, measured in meters from the beacon
-    let accuracy: CLLocationAccuracy
+    public let accuracy: CLLocationAccuracy
 
     /// The most recent timestamp representing when the beacon was observed
-    let timestamp: Int64
+    public let timestamp: Int64
 }


### PR DESCRIPTION
This pull request makes changes to the `Beacon` struct in the `Sources/SDBeaconScanner/Beacon.swift` file to improve its accessibility. The most important changes involve updating the visibility of several properties to make them publicly accessible.

### Changes to `Beacon` struct:

* Updated the visibility of the `uuid`, `major`, `minor`, `rssi`, `proximity`, `timestamp`, and `accuracy` properties from `internal` to `public`, allowing these properties to be accessed outside the module.